### PR TITLE
Clear OSF when setting time

### DIFF
--- a/lib/nerves_time/rtc/ds3231/status.ex
+++ b/lib/nerves_time/rtc/ds3231/status.ex
@@ -1,6 +1,9 @@
 defmodule NervesTime.RTC.DS3231.Status do
   @moduledoc false
 
+  @typedoc "The DS3231 status registers are a 1-byte binary."
+  @type registers :: <<_::8>>
+
   @doc """
   Return a list of commands for reading the Status register
   """
@@ -9,19 +12,35 @@ defmodule NervesTime.RTC.DS3231.Status do
     [{:write_read, <<0x0F>>, 1}]
   end
 
-  @spec decode(<<_::8>>) :: {:ok, map()} | {:error, any()}
+  @spec encode(map()) :: {:ok, registers()}
+  def encode(%{
+        osc_stop_flag: osc_stop_flag,
+        busy: busy,
+        ena_32khz_out: ena_32khz_out,
+        alarm_2_flag: alarm_2_flag,
+        alarm_1_flag: alarm_1_flag
+      }) do
+    bin =
+      <<osc_stop_flag::size(1), 0::size(3), ena_32khz_out::size(1), busy::size(1),
+        alarm_2_flag::size(1), alarm_1_flag::size(1)>>
+
+    {:ok, bin}
+  end
+
+  @spec decode(registers()) :: {:ok, map()} | {:error, any()}
   def decode(
-        <<osc_stop_flag::integer-1, _::integer-3, ena_32khz_out::integer-1, busy::integer-1,
-          alarm_2_flag::integer-1, alarm_1_flag::integer-1>>
+        <<osc_stop_flag::size(1), _::size(3), ena_32khz_out::size(1), busy::size(1),
+          alarm_2_flag::size(1), alarm_1_flag::size(1)>>
       ) do
-    {:ok,
-     %{
-       osc_stop_flag: osc_stop_flag,
-       busy: busy,
-       ena_32khz_out: ena_32khz_out,
-       alarm_2_flag: alarm_2_flag,
-       alarm_1_flag: alarm_1_flag
-     }}
+    data = %{
+      osc_stop_flag: osc_stop_flag,
+      busy: busy,
+      ena_32khz_out: ena_32khz_out,
+      alarm_2_flag: alarm_2_flag,
+      alarm_1_flag: alarm_1_flag
+    }
+
+    {:ok, data}
   end
 
   def decode(_other), do: {:error, :invalid}

--- a/test/nerves_time/rtc/ds3231/status_test.exs
+++ b/test/nerves_time/rtc/ds3231/status_test.exs
@@ -2,9 +2,17 @@ defmodule NervesTime.RTC.DS3231.StatusTest do
   use ExUnit.Case
   alias NervesTime.RTC.DS3231.Status
 
-  test "decodes Status" do
-    assert Status.decode(<<0xFF>>) ==
-             {:ok,
-              %{alarm_1_flag: 1, alarm_2_flag: 1, busy: 1, ena_32khz_out: 1, osc_stop_flag: 1}}
+  test "decode/1 and encode/1" do
+    data = %{
+      alarm_1_flag: 1,
+      alarm_2_flag: 1,
+      busy: 1,
+      ena_32khz_out: 1,
+      osc_stop_flag: 1
+    }
+
+    bin = <<0x8F>>
+    assert {:ok, data} == Status.decode(bin)
+    assert {:ok, bin} == Status.encode(data)
   end
 end


### PR DESCRIPTION
Why
---

- The OSF gets set to `1` in the following cases:
  - The first time power is applied.
  - Vcc and Vbat voltage cannot support oscillation.
  - The EOSC bit is turned off in battery-backed mode.
  - External influences on the crystal (i.e., noise, leakage, etc.).
- ...The OSF will remain set until explicitly written to. The only safe
  time to do this is when an external time is provided (NTP, etc.).

How
---

- `NervesTime.RTC.DS3231.set_time/2` now reads the status register,
  clears the OSF, and writes the status register only after successfully
  writing the date register.
- Add `NervesTime.RTC.DS3231.Status.encode/1`.

Side effects
------------

- Remove private
  `NervesTime.RTC.DS3231.{rtc_available?/2, supported?/1}`. These were
  only being used when `NervesTime` would try to initialize this
  library. The only check they were performing was whether the OSF was
  set, if it was, this library would fail to start and crash
  `NervesTime`. This is undesirable due to the above text with respect
  to the OSF - we need to be able to leverage `NervesTime` and likely
  NTP to obtain a valid time, write it to the RTC, and clear the OSF.