### PR TITLE
Century support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,19 @@ And then update your `:nerves_time` configuration to point to it:
 config :nerves_time, rtc: NervesTime.RTC.DS3231
 ```
 
-It's possible to override the default I2C bus and address via options:
+It's possible to override the default I2C bus, I2C address, and current `:century` via options:
 
 ```elixir
-config :nerves_time, rtc: {NervesTime.RTC.DS3231, [bus_name: "i2c-2", address:
-0x69]}
+rtc_opts = [
+  address: 0x68,
+  bus_name: "i2c-1",
+  century: 2000
+]
+config :nerves_time, rtc: {NervesTime.RTC.DS3231, rtc_opts}
 ```
+
+The `:century` option indicates to this library what century to associate with the DS3231's
+century bit set to logic `0`. Logic `1` is associated with `:century` plus 100. Internally the
+DS3231 will toggle its century bit when its years counter rolls over.
 
 Check the logs for error messages if the RTC doesn't appear to work.

--- a/lib/nerves_time/rtc/ds3231.ex
+++ b/lib/nerves_time/rtc/ds3231.ex
@@ -9,11 +9,20 @@ defmodule NervesTime.RTC.DS3231 do
   config :nerves_time, rtc: NervesTime.RTC.DS3231
   ```
 
-  If not using `"i2c-1"` or the default I2C bus address, specify them like this:
+  To override the default I2C bus, I2C address, or centuries one may:
 
   ```elixir
-  config :nerves_time, rtc: {NervesTime.RTC.DS3231, [bus_name: "i2c-2", address: 0x69]}
+  rtc_opts = [
+    address: 0x68,
+    bus_name: "i2c-1",
+    century: 2000
+  ]
+  config :nerves_time, rtc: {NervesTime.RTC.DS3231, rtc_opts}
   ```
+
+  The `:century` option indicates to this library what century to choose when the DS3231's century
+  bit is set to logic `0`. When the bit is logic `1` the cetury will be the value of `:century`
+  plus 100. Internally the DS3231 will toggle its century bit when its years counter rolls over.
 
   Check the logs for error messages if the RTC doesn't appear to work.
 
@@ -27,26 +36,46 @@ defmodule NervesTime.RTC.DS3231 do
   alias Circuits.I2C
   alias NervesTime.RTC.DS3231.{Date, Status}
 
-  @default_bus_name "i2c-1"
   @default_address 0x68
+  @default_bus_name "i2c-1"
+  @default_century_0 2000
+
+  @typedoc """
+  A number representing a century.
+
+  For example, 2000 or 2100.
+  """
+  @type century() :: integer()
 
   @typedoc "This type represents the many registers whose value is a single bit."
   @type flag :: 0 | 1
 
   @typedoc false
   @type state :: %{
-          i2c: I2C.bus(),
+          address: I2C.address(),
           bus_name: String.t(),
-          address: I2C.address()
+          century_0: I2C.address(),
+          century_1: I2C.address(),
+          i2c: I2C.bus()
         }
 
   @impl NervesTime.RealTimeClock
   def init(args) do
-    bus_name = Keyword.get(args, :bus_name, @default_bus_name)
     address = Keyword.get(args, :address, @default_address)
+    bus_name = Keyword.get(args, :bus_name, @default_bus_name)
 
     with {:ok, i2c} <- I2C.open(bus_name) do
-      {:ok, %{i2c: i2c, bus_name: bus_name, address: address}}
+      century_0 = Keyword.get(args, :century_0, @default_century_0)
+
+      state = %{
+        address: address,
+        bus_name: bus_name,
+        century_0: century_0,
+        century_1: century_0 + 100,
+        i2c: i2c
+      }
+
+      {:ok, state}
     else
       {:error, _} = error ->
         error
@@ -61,7 +90,7 @@ defmodule NervesTime.RTC.DS3231 do
 
   @impl NervesTime.RealTimeClock
   def set_time(state, now) do
-    with {:ok, date_registers} <- Date.encode(now),
+    with {:ok, date_registers} <- Date.encode(now, state.century_0, state.century_1),
          {:ok, status_registers} <- I2C.write_read(state.i2c, state.address, <<0x0F>>, 1),
          {:ok, status_data} <- Status.decode(status_registers),
          {:ok, status_registers} <- Status.encode(%{status_data | osc_stop_flag: 0}),
@@ -78,7 +107,7 @@ defmodule NervesTime.RTC.DS3231 do
   @impl NervesTime.RealTimeClock
   def get_time(state) do
     with {:ok, registers} <- I2C.write_read(state.i2c, state.address, <<0>>, 7),
-         {:ok, time} <- Date.decode(registers) do
+         {:ok, time} <- Date.decode(registers, state.century_0, state.century_1) do
       {:ok, time, state}
     else
       any_error ->

--- a/lib/nerves_time/rtc/ds3231/date.ex
+++ b/lib/nerves_time/rtc/ds3231/date.ex
@@ -1,7 +1,11 @@
 defmodule NervesTime.RTC.DS3231.Date do
   @moduledoc false
 
-  alias NervesTime.RealTimeClock.BCD
+  alias NervesTime.{RealTimeClock.BCD, RTC.DS3231}
+  require Bitwise
+
+  @typedoc "The DS3231 date registers are a 7-byte binary."
+  @type date_registers() :: <<_::56>>
 
   @doc """
   Return a list of commands for reading and writing the time-date registers
@@ -14,55 +18,73 @@ defmodule NervesTime.RTC.DS3231.Date do
   @doc """
   Decode register values into a date
 
-  This only returns years between 2000 and 2099.
+  Only decodes dates `>= century_0` and `< century_1 + 100`.
   """
-  @spec decode(<<_::56>>) :: {:ok, NaiveDateTime.t()} | {:error, any()}
-  def decode(<<seconds_bcd, minutes_bcd, hours24_bcd, _day, date_bcd, month_bcd, year_bcd>>) do
-    {:ok,
-     %NaiveDateTime{
-       microsecond: {0, 0},
-       second: BCD.to_integer(seconds_bcd),
-       minute: BCD.to_integer(minutes_bcd),
-       hour: BCD.to_integer(hours24_bcd),
-       day: BCD.to_integer(date_bcd),
-       month: BCD.to_integer(month_bcd),
-       year: 2000 + BCD.to_integer(year_bcd)
-     }}
+  @spec decode(date_registers(), DS3231.century(), DS3231.century()) ::
+          {:ok, NaiveDateTime.t()} | {:error, any()}
+  def decode(
+        <<seconds_bcd, minutes_bcd, hours24_bcd, _day, date_bcd, century::size(1),
+          month_bcd::size(7), year_bcd>>,
+        century_0,
+        century_1
+      ) do
+    century = if century == 0, do: century_0, else: century_1
+
+    date_time = %NaiveDateTime{
+      microsecond: {0, 0},
+      second: BCD.to_integer(seconds_bcd),
+      minute: BCD.to_integer(minutes_bcd),
+      hour: BCD.to_integer(hours24_bcd),
+      day: BCD.to_integer(date_bcd),
+      month: BCD.to_integer(month_bcd),
+      year: century + BCD.to_integer(year_bcd)
+    }
+
+    {:ok, date_time}
   end
 
-  def decode(_other), do: {:error, :invalid}
+  def decode(_, _, _), do: {:error, :invalid}
 
   @doc """
   Encode the specified date to register values.
 
-  Only dates between 2001 and 2099 are supported. This avoids the need to deal
-  with the leap year special case for 2000. That would involve setting the
-  century bit and that seems like a pointless complexity for a date that has come and gone.
+  Only encodes dates `>= century_0` and `< century_1 + 100`.
   """
-  @spec encode(NaiveDateTime.t()) :: {:ok, <<_::56>>} | {:error, any()}
-  def encode(%NaiveDateTime{year: year} = date_time) when year > 2000 and year < 2100 do
+  @spec encode(NaiveDateTime.t(), DS3231.century(), DS3231.century()) ::
+          {:ok, date_registers()} | {:error, any()}
+  def encode(%NaiveDateTime{year: year} = date_time, century_0, century_1)
+      when year >= century_0 and year < century_1 + 100 do
     {microseconds, _precision} = date_time.microsecond
     seconds_bcd = BCD.from_integer(round(date_time.second + microseconds / 1_000_000))
     minutes_bcd = BCD.from_integer(date_time.minute)
     hours24_bcd = BCD.from_integer(date_time.hour)
     day_bcd = BCD.from_integer(Calendar.ISO.day_of_week(year, date_time.month, date_time.day))
     date_bcd = BCD.from_integer(date_time.day)
-    month_bcd = BCD.from_integer(date_time.month)
-    year_bcd = BCD.from_integer(year - 2000)
+    {century, century_mask} = resolve_century(year, century_0, century_1)
+    month_bcd = Bitwise.bor(century_mask, BCD.from_integer(date_time.month))
+    year_bcd = BCD.from_integer(year - century)
 
-    {:ok,
-     <<
-       seconds_bcd,
-       minutes_bcd,
-       hours24_bcd,
-       day_bcd,
-       date_bcd,
-       month_bcd,
-       year_bcd
-     >>}
+    bin = <<
+      seconds_bcd,
+      minutes_bcd,
+      hours24_bcd,
+      day_bcd,
+      date_bcd,
+      month_bcd,
+      year_bcd
+    >>
+
+    {:ok, bin}
   end
 
-  def encode(_invalid_date) do
-    {:error, :invalid_date}
+  def encode(_, _, _), do: {:error, :invalid_date}
+
+  defp resolve_century(year, century_0, century_1) when year >= century_0 and year < century_1 do
+    {century_0, 0b0000_0000}
+  end
+
+  defp resolve_century(year, _, century_1)
+       when year >= century_1 and year < century_1 + 100 do
+    {century_1, 0b1000_0000}
   end
 end


### PR DESCRIPTION
Why
---

- When the DS3231 overflows the 2-digit years it is tracking, the
  "century" bit gets toggled. In practice, a library must define what
  it considers "century_0" and "century_1" so that it can sum the
  decided century with the tracked years.

How
---

- Add `:century` configuration. Document in readme and `DS3231`. Default
  to `2000`. Note the interface only exposes a single century option;
  this is because there is an expectation that they are contiguous.

----

....so looks like we'll be set here for ~180 years give or take 🧝🏻.