### PR TITLE
Support alarms, temperature, control, and status

### DIFF
--- a/lib/nerves_time/rtc/ds3231.ex
+++ b/lib/nerves_time/rtc/ds3231.ex
@@ -95,6 +95,13 @@ defmodule NervesTime.RTC.DS3231 do
 
   @doc "Writes the control register."
   def set_control(i2c, address, control), do: set(i2c, address, 0x0E, control, Control)
+  @doc "Reads an alarm register."
+  def get_alarm(i2c, address, 1 = _alarm_num), do: get(i2c, address, 0x07, 4, Alarm)
+  def get_alarm(i2c, address, 2 = _alarm_num), do: get(i2c, address, 0x0B, 3, Alarm)
+
+  @doc "Writes an alarm register."
+  def set_alarm(i2c, address, %{seconds: _} = a1), do: set(i2c, address, 0x07, a1, Alarm)
+  def set_alarm(i2c, address, a2), do: set(i2c, address, 0x0B, a2, Alarm)
 
   defp set(i2c, address, offset, data, module) do
     with {:ok, bin} <- module.encode(data),

--- a/lib/nerves_time/rtc/ds3231.ex
+++ b/lib/nerves_time/rtc/ds3231.ex
@@ -25,7 +25,7 @@ defmodule NervesTime.RTC.DS3231 do
   require Logger
 
   alias Circuits.I2C
-  alias NervesTime.RTC.DS3231.{Date, Status}
+  alias NervesTime.RTC.DS3231.{Alarm, Date, Status}
 
   @default_bus_name "i2c-1"
   @default_address 0x68
@@ -61,12 +61,9 @@ defmodule NervesTime.RTC.DS3231 do
 
   @impl NervesTime.RealTimeClock
   def set_time(state, now) do
-    with {:ok, date_registers} <- Date.encode(now),
-         {:ok, status_registers} <- I2C.write_read(state.i2c, state.address, <<0x0F>>, 1),
-         {:ok, status_data} <- Status.decode(status_registers),
-         {:ok, status_registers} <- Status.encode(%{status_data | osc_stop_flag: 0}),
-         :ok <- I2C.write(state.i2c, state.address, [0x00, date_registers]),
-         :ok <- I2C.write(state.i2c, state.address, [0x0F, status_registers]) do
+    with {:ok, status_data} <- get_status(state.i2c, state.address),
+         :ok <- set(state.i2c, state.address, 0x0F, now, Date),
+         :ok <- set_status(state.i2c, state.address, %{status_data | osc_stop_flag: 0}) do
       state
     else
       error ->
@@ -84,6 +81,32 @@ defmodule NervesTime.RTC.DS3231 do
       any_error ->
         _ = Logger.error("DS3231 RTC not set or has an error: #{inspect(any_error)}")
         {:unset, state}
+    end
+  end
+
+  @doc "Reads the status register."
+  def get_status(i2c, address), do: get(i2c, address, 0x0F, 1, Status)
+
+  @doc "Writes the status register."
+  def set_status(i2c, address, status), do: set(i2c, address, 0x0F, status, Status)
+
+  defp set(i2c, address, offset, data, module) do
+    with {:ok, bin} <- module.encode(data),
+         :ok <- I2C.write(i2c, address, [offset, bin]) do
+      :ok
+    else
+      {:error, _} = e -> e
+      e -> {:error, e}
+    end
+  end
+
+  defp get(i2c, address, offset, length, module) do
+    with {:ok, bin} <- I2C.write_read(i2c, address, <<offset>>, length),
+         {:ok, data} <- module.decode(bin) do
+      {:ok, data}
+    else
+      {:error, _} = e -> e
+      e -> {:error, e}
     end
   end
 end

--- a/lib/nerves_time/rtc/ds3231.ex
+++ b/lib/nerves_time/rtc/ds3231.ex
@@ -25,7 +25,7 @@ defmodule NervesTime.RTC.DS3231 do
   require Logger
 
   alias Circuits.I2C
-  alias NervesTime.RTC.DS3231.{Alarm, Control, Date, Status}
+  alias NervesTime.RTC.DS3231.{Alarm, Control, Date, Status, Temperature}
 
   @default_bus_name "i2c-1"
   @default_address 0x68
@@ -102,6 +102,9 @@ defmodule NervesTime.RTC.DS3231 do
   @doc "Writes an alarm register."
   def set_alarm(i2c, address, %{seconds: _} = a1), do: set(i2c, address, 0x07, a1, Alarm)
   def set_alarm(i2c, address, a2), do: set(i2c, address, 0x0B, a2, Alarm)
+
+  @doc "Reads the temperature register."
+  def get_temperature(i2c, address), do: get(i2c, address, 0x11, 2, Temperature)
 
   defp set(i2c, address, offset, data, module) do
     with {:ok, bin} <- module.encode(data),

--- a/lib/nerves_time/rtc/ds3231.ex
+++ b/lib/nerves_time/rtc/ds3231.ex
@@ -25,7 +25,7 @@ defmodule NervesTime.RTC.DS3231 do
   require Logger
 
   alias Circuits.I2C
-  alias NervesTime.RTC.DS3231.{Alarm, Date, Status}
+  alias NervesTime.RTC.DS3231.{Alarm, Control, Date, Status}
 
   @default_bus_name "i2c-1"
   @default_address 0x68
@@ -89,6 +89,12 @@ defmodule NervesTime.RTC.DS3231 do
 
   @doc "Writes the status register."
   def set_status(i2c, address, status), do: set(i2c, address, 0x0F, status, Status)
+
+  @doc "Reads the control register."
+  def get_control(i2c, address), do: get(i2c, address, 0x0E, 1, Control)
+
+  @doc "Writes the control register."
+  def set_control(i2c, address, control), do: set(i2c, address, 0x0E, control, Control)
 
   defp set(i2c, address, offset, data, module) do
     with {:ok, bin} <- module.encode(data),

--- a/lib/nerves_time/rtc/ds3231/alarm.ex
+++ b/lib/nerves_time/rtc/ds3231/alarm.ex
@@ -68,10 +68,6 @@ defmodule NervesTime.RTC.DS3231.Alarm do
         minutes: minutes,
         seconds: seconds
       }) do
-    a1m1 = a1m1
-    a1m2 = a1m2
-    a1m3 = a1m3
-    a1m4 = a1m4
     seconds = BCD.from_integer(seconds)
     minutes = BCD.from_integer(minutes)
     hours = BCD.from_integer(hours)

--- a/lib/nerves_time/rtc/ds3231/alarm.ex
+++ b/lib/nerves_time/rtc/ds3231/alarm.ex
@@ -1,0 +1,99 @@
+defmodule NervesTime.RTC.DS3231.Alarm do
+  @moduledoc false
+
+  alias NervesTime.RealTimeClock.BCD
+
+  @typedoc "The DS3231 alarm registers are a 4-byte or 3-byte binary."
+  @type alarm_registers() :: <<_::4>> | <<_::3>>
+
+  @doc """
+  Decode register values into an alarm.
+  """
+  @spec decode(alarm_registers()) :: {:ok, map()} | {:error, any()}
+  def decode(
+        <<
+          alarm_1_mask_1::1,
+          seconds::7,
+          alarm_1_mask_2::1,
+          minutes::7,
+          alarm_1_mask_3::1,
+          hours::7,
+          alarm_1_mask_4::1,
+          day::7
+        >> = _alarm_1
+      ) do
+    alarm_1 = %{
+      alarm_1_mask_1: alarm_1_mask_1,
+      alarm_1_mask_2: alarm_1_mask_2,
+      alarm_1_mask_3: alarm_1_mask_3,
+      alarm_1_mask_4: alarm_1_mask_4,
+      seconds: BCD.to_integer(seconds),
+      minutes: BCD.to_integer(minutes),
+      hours: BCD.to_integer(hours),
+      day: BCD.to_integer(day)
+    }
+
+    {:ok, alarm_1}
+  end
+
+  def decode(
+        <<alarm_2_mask_1::1, minutes::7, alarm_2_mask_2::1, hours::7, alarm_2_mask_3::1, day::7>> =
+          _alarm_2
+      ) do
+    alarm_2 = %{
+      alarm_2_mask_1: alarm_2_mask_1,
+      alarm_2_mask_2: alarm_2_mask_2,
+      alarm_2_mask_3: alarm_2_mask_3,
+      minutes: BCD.to_integer(minutes),
+      hours: BCD.to_integer(hours),
+      day: BCD.to_integer(day)
+    }
+
+    {:ok, alarm_2}
+  end
+
+  def decode(_), do: {:error, :invalid}
+
+  @doc """
+  Encode `alarm` to register values.
+  """
+  @spec encode(map()) :: {:ok, alarm_registers()} | {:error, :invalid}
+  def encode(%{
+        alarm_1_mask_1: a1m1,
+        alarm_1_mask_2: a1m2,
+        alarm_1_mask_3: a1m3,
+        alarm_1_mask_4: a1m4,
+        day: day,
+        hours: hours,
+        minutes: minutes,
+        seconds: seconds
+      }) do
+    a1m1 = a1m1
+    a1m2 = a1m2
+    a1m3 = a1m3
+    a1m4 = a1m4
+    seconds = BCD.from_integer(seconds)
+    minutes = BCD.from_integer(minutes)
+    hours = BCD.from_integer(hours)
+    day = BCD.from_integer(day)
+    bin = <<a1m1::1, seconds::7, a1m2::1, minutes::7, a1m3::1, hours::7, a1m4::1, day::7>>
+    {:ok, bin}
+  end
+
+  def encode(%{
+        alarm_2_mask_1: a2m1,
+        alarm_2_mask_2: a2m2,
+        alarm_2_mask_3: a2m3,
+        day: day,
+        hours: hours,
+        minutes: minutes
+      }) do
+    minutes = BCD.from_integer(minutes)
+    hours = BCD.from_integer(hours)
+    day = BCD.from_integer(day)
+    bin = <<a2m1::1, minutes::7, a2m2::1, hours::7, a2m3::1, day::7>>
+    {:ok, bin}
+  end
+
+  def encode(_), do: {:error, :invalid}
+end

--- a/lib/nerves_time/rtc/ds3231/control.ex
+++ b/lib/nerves_time/rtc/ds3231/control.ex
@@ -1,6 +1,9 @@
 defmodule NervesTime.RTC.DS3231.Control do
   @moduledoc false
 
+  @typedoc "The DS3231 control registers are a 1-byte binary."
+  @type registers :: <<_::8>>
+
   @doc """
   Return a list of commands for reading the Control register
   """
@@ -9,17 +12,44 @@ defmodule NervesTime.RTC.DS3231.Control do
     [{:write_read, <<0x0E>>, 1}]
   end
 
-  @spec decode(<<_::8>>) :: {:ok, map()} | {:error, any()}
+  @spec decode(registers()) :: {:ok, map()} | {:error, any()}
   def decode(
-        <<osc_enable::integer-1, _bbsqw::integer-1, _conv_temp::integer-1, _rate_sel_1::integer-1,
-          _rate_sel_0::integer-1, _interrupt_control::integer-1, _alarm_2_int_ena::integer-1,
-          _alarm_1_int_ena::integer-1>>
+        <<osc_enable::1, bbsqw::1, conv_temp::1, rate_sel_1::1, rate_sel_0::1,
+          interrupt_control::1, alarm_2_int_ena::1, alarm_1_int_ena::1>>
       ) do
-    {:ok,
-     %{
-       osc_enable_: osc_enable
-     }}
+    data = %{
+      alarm_1_int_ena: alarm_1_int_ena,
+      alarm_2_int_ena: alarm_2_int_ena,
+      bbsqw: bbsqw,
+      conv_temp: conv_temp,
+      interrupt_control: interrupt_control,
+      rate_sel_0: rate_sel_0,
+      rate_sel_1: rate_sel_1,
+      osc_enable_: osc_enable
+    }
+
+    {:ok, data}
   end
 
   def decode(_other), do: {:error, :invalid}
+
+  @spec encode(map()) :: {:ok, registers()}
+  def encode(%{
+        alarm_1_int_ena: alarm_1_int_ena,
+        alarm_2_int_ena: alarm_2_int_ena,
+        bbsqw: bbsqw,
+        conv_temp: conv_temp,
+        interrupt_control: interrupt_control,
+        rate_sel_0: rate_sel_0,
+        rate_sel_1: rate_sel_1,
+        osc_enable_: osc_enable
+      }) do
+    bin =
+      <<osc_enable::1, bbsqw::1, conv_temp::1, rate_sel_1::1, rate_sel_0::1, interrupt_control::1,
+        alarm_2_int_ena::1, alarm_1_int_ena::1>>
+
+    {:ok, bin}
+  end
+
+  def encode(_), do: {:error, :invalid}
 end

--- a/lib/nerves_time/rtc/ds3231/status.ex
+++ b/lib/nerves_time/rtc/ds3231/status.ex
@@ -23,21 +23,6 @@ defmodule NervesTime.RTC.DS3231.Status do
     [{:write_read, <<0x0F>>, 1}]
   end
 
-  @spec encode(data()) :: {:ok, registers()}
-  def encode(%{
-        osc_stop_flag: osc_stop_flag,
-        busy: busy,
-        ena_32khz_out: ena_32khz_out,
-        alarm_2_flag: alarm_2_flag,
-        alarm_1_flag: alarm_1_flag
-      }) do
-    bin =
-      <<osc_stop_flag::size(1), 0::size(3), ena_32khz_out::size(1), busy::size(1),
-        alarm_2_flag::size(1), alarm_1_flag::size(1)>>
-
-    {:ok, bin}
-  end
-
   @spec decode(registers()) :: {:ok, map()} | {:error, any()}
   def decode(
         <<osc_stop_flag::size(1), _::size(3), ena_32khz_out::size(1), busy::size(1),
@@ -55,4 +40,21 @@ defmodule NervesTime.RTC.DS3231.Status do
   end
 
   def decode(_other), do: {:error, :invalid}
+
+  @spec encode(data()) :: {:ok, registers()}
+  def encode(%{
+        osc_stop_flag: osc_stop_flag,
+        busy: busy,
+        ena_32khz_out: ena_32khz_out,
+        alarm_2_flag: alarm_2_flag,
+        alarm_1_flag: alarm_1_flag
+      }) do
+    bin =
+      <<osc_stop_flag::size(1), 0::size(3), ena_32khz_out::size(1), busy::size(1),
+        alarm_2_flag::size(1), alarm_1_flag::size(1)>>
+
+    {:ok, bin}
+  end
+
+  def encode(_), do: {:error, :invalid}
 end

--- a/lib/nerves_time/rtc/ds3231/temperature.ex
+++ b/lib/nerves_time/rtc/ds3231/temperature.ex
@@ -1,0 +1,17 @@
+defmodule NervesTime.RTC.DS3231.Temperature do
+  @moduledoc false
+
+  @typedoc "The DS3231 temperature registers are a 2-byte binary."
+  @type registers :: <<_::16>>
+
+  @spec decode(registers()) :: {:ok, map()} | {:error, any()}
+  def decode(<<sign_bit::size(1), upper::size(7), lower::size(2), _::bits>>) do
+    places = if lower == 1, do: 2, else: 1
+    fraction = if lower == 0, do: 0, else: Enum.reduce(1..places, lower, fn _, acc -> acc / 2 end)
+    sign = if sign_bit == 1, do: -1, else: 1
+    celsius = sign * (upper + fraction)
+    {:ok, %{celsius: celsius}}
+  end
+
+  def decode(_other), do: {:error, :invalid}
+end

--- a/test/nerves_time/rtc/ds3231/alarm_test.exs
+++ b/test/nerves_time/rtc/ds3231/alarm_test.exs
@@ -1,0 +1,66 @@
+defmodule NervesTime.RTC.DS3231.AlarmTest do
+  use ExUnit.Case
+  alias NervesTime.RTC.DS3231.Alarm
+
+  describe "decode/1 and encode/1" do
+    test "alarm_1" do
+      alarm_1 = %{
+        alarm_1_mask_1: 0,
+        alarm_1_mask_2: 1,
+        alarm_1_mask_3: 0,
+        alarm_1_mask_4: 1,
+        seconds: 1,
+        minutes: 2,
+        hours: 3,
+        day: 20
+      }
+
+      bin_1 = <<1, 130, 3, 160>>
+      assert {:ok, bin_1} == Alarm.encode(alarm_1)
+      assert {:ok, alarm_1} == Alarm.decode(bin_1)
+
+      alarm_1 = %{
+        alarm_1_mask_1: 1,
+        alarm_1_mask_2: 0,
+        alarm_1_mask_3: 1,
+        alarm_1_mask_4: 0,
+        seconds: 3,
+        minutes: 5,
+        hours: 9,
+        day: 16
+      }
+
+      bin_1 = <<131, 5, 137, 22>>
+      assert {:ok, bin_1} == Alarm.encode(alarm_1)
+      assert {:ok, alarm_1} == Alarm.decode(bin_1)
+    end
+
+    test "alarm_2" do
+      alarm_2 = %{
+        alarm_2_mask_1: 0,
+        alarm_2_mask_2: 1,
+        alarm_2_mask_3: 0,
+        minutes: 2,
+        hours: 3,
+        day: 20
+      }
+
+      bin_2 = <<2, 131, 32>>
+      assert {:ok, bin_2} == Alarm.encode(alarm_2)
+      assert {:ok, alarm_2} == Alarm.decode(bin_2)
+
+      alarm_2 = %{
+        alarm_2_mask_1: 1,
+        alarm_2_mask_2: 0,
+        alarm_2_mask_3: 1,
+        minutes: 55,
+        hours: 43,
+        day: 30
+      }
+
+      bin_2 = <<213, 67, 176>>
+      assert {:ok, bin_2} == Alarm.encode(alarm_2)
+      assert {:ok, alarm_2} == Alarm.decode(bin_2)
+    end
+  end
+end

--- a/test/nerves_time/rtc/ds3231/control_test.exs
+++ b/test/nerves_time/rtc/ds3231/control_test.exs
@@ -1,0 +1,36 @@
+defmodule NervesTime.RTC.DS3231.ControlTest do
+  use ExUnit.Case
+  alias NervesTime.RTC.DS3231.Control
+
+  test "decode/1 and encode/1" do
+    data = %{
+      alarm_1_int_ena: 1,
+      alarm_2_int_ena: 1,
+      bbsqw: 1,
+      conv_temp: 1,
+      interrupt_control: 1,
+      rate_sel_0: 1,
+      rate_sel_1: 1,
+      osc_enable_: 1
+    }
+
+    bin = <<255>>
+    assert {:ok, bin} == Control.encode(data)
+    assert {:ok, data} == Control.decode(bin)
+
+    data = %{
+      alarm_1_int_ena: 0,
+      alarm_2_int_ena: 0,
+      bbsqw: 0,
+      conv_temp: 0,
+      interrupt_control: 0,
+      rate_sel_0: 0,
+      rate_sel_1: 0,
+      osc_enable_: 0
+    }
+
+    bin = <<0>>
+    assert {:ok, bin} == Control.encode(data)
+    assert {:ok, data} == Control.decode(bin)
+  end
+end

--- a/test/nerves_time/rtc/ds3231/temperature_test.exs
+++ b/test/nerves_time/rtc/ds3231/temperature_test.exs
@@ -1,0 +1,10 @@
+defmodule NervesTime.RTC.DS3231.TemperatureTest do
+  use ExUnit.Case
+  alias NervesTime.RTC.DS3231.Temperature
+
+  test "decode/1 and encode/1" do
+    data = %{celsius: 25.25}
+    bin = <<0b0001_1001>> <> <<0b0100_0000>>
+    assert {:ok, data} == Temperature.decode(bin)
+  end
+end


### PR DESCRIPTION
To take smaller bites of the PR at a time view the commits individually.

Add support for status, control, alarm, and temperature registers. I have verified all of this on-board and added tests.

**_NOTE_**: There are still 13 unsupported bits out of all the registers.

- reg `0x02` bit `6` - toggle 24 hours versus AM/PM for main clock
- reg `0x09` bit `6` - toggle 24 hours versus AM/PM for alarm 1 hours
- reg `0x0A` bit `6` - toggle day (1-7) versus date (1-31) for alarm 1
- reg `0x0C` bit `6` - toggle 24 hours versus AM/PM for alarm 2 hours
- reg `0x0D` bit `6` - toggle day (1-7) versus date (1-31) for alarm 2
- reg `0x10` all 8 bits - aging offset